### PR TITLE
Add privacy page #40

### DIFF
--- a/app.py
+++ b/app.py
@@ -302,6 +302,10 @@ def html_rend_file_browser():
 def boardwalk():
     return redirect(url_for('boardwalk'))
 
+@app.route('/privacy')
+def privacy():
+    return redirect(url_for('privacy'))
+
 
 @app.route('/token')
 def token():

--- a/templates/base.html
+++ b/templates/base.html
@@ -177,7 +177,7 @@
 
 				 <!-- Copyright row -->
 				 <div class="cgl-disclaimer layout-column layout-gt-sm-row">
-					  <span>Copyright © 2016, The Regents of the University of California, Santa Cruz.</span>&nbsp; <span> All Rights Reserved. Apache-2.0 licence.</span>
+					  <span>Copyright © 2018, The Regents of the University of California, Santa Cruz.</span>&nbsp; <span> All Rights Reserved. Apache-2.0 licence.</span>
 				 </div>
 
         {% endblock %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,0 +1,30 @@
+{% extends "base.html" %}
+{% block title %} Privacy Policy  {% endblock %}
+{% block page_Privacy %} class="active" {% endblock %}
+{% block content %}
+    <main class="layout-column layout-padding flex">
+        <section class="snap-960">
+            <h1 class="md-display-1" style="color:#FF6B6B;">Privacy Policy</h1>
+            <p class="md-body-1">The University of California is committed to protecting the privacy and accuracy of
+                your personally identifiable information to the extent possible, subject to provisions of state and
+                federal law. Other than as required by laws that guarantee public access to certain types of information, or
+                in response to subpoenas or other legal instruments that authorize disclosure, personally identifiable
+                information is not disclosed without your consent.</p>
+            <p class="md-body-1">
+                We may log your IP address to help diagnose any problems, but we do not link IP addresses to anything
+                personally identifiable. You can visit the UCSC Analysis Core website without identifying yourself,
+                or for certain features, you may be required to login with Google. If you login, we only use the
+                information verify your identity. This information is not shared with anyone.
+            </p>
+            <p class="md-body-1">You may encounter links to other Web sites of organizations not directly affiliated
+                with the University of California. Please be aware that the University of California is not responsible
+                for the information practices of external organizations. We recommend you review the privacy statements
+                of each external Web site that collects personal information.</p>
+        </section>
+    </main>
+{% endblock %}
+
+
+
+
+


### PR DESCRIPTION
Took [Genome Browser Privacy](https://genome-store.ucsc.edu/pages/privacy/) as a starting point. Updated it to include things that Google seems to want -- what info we store, how we use it, and do we share it.

For now I decided not to directly expose a link to the privacy policy on the website -- the user will have to know the url (/privacy.html), but this way we can at least point someone to it.

Here's what it looks like:
![screen shot 2018-03-09 at 3 30 12 pm](https://user-images.githubusercontent.com/1049340/37234834-fe2e46f8-23ae-11e8-848b-3fe48c1d20a5.png)
