### PR TITLE
Remove Request for Privileged Google Scope

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ class Auth:
     AUTH_URI = 'https://accounts.google.com/o/oauth2/auth'
     TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
     USER_INFO = 'https://www.googleapis.com/userinfo/v2/me'
-    SCOPE = ['profile', 'email', 'https://www.googleapis.com/auth/devstorage.full_control']
+    SCOPE = ['profile', 'email']
 
 
 class Config:


### PR DESCRIPTION
Removed `devstorage.full_control scope` when performing Google authentication in Dashboard.
This was formerly required by the Broad Institute's FireCloud workspace, yet they recently changed their system to not require this scope, so we should not request approval for this advanced scope from our users.