### PR TITLE
Request fully qualified Google scopes

### DIFF
--- a/app.py
+++ b/app.py
@@ -47,7 +47,8 @@ class Auth:
     AUTH_URI = 'https://accounts.google.com/o/oauth2/auth'
     TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
     USER_INFO = 'https://www.googleapis.com/userinfo/v2/me'
-    SCOPE = ['profile', 'email']
+    SCOPE = ['https://www.googleapis.com/auth/userinfo.profile',
+             'https://www.googleapis.com/auth/userinfo.email']
 
 
 class Config:


### PR DESCRIPTION
#48

After refreshing the access token, the newly issued access token
had the https://www.googleapis.com/auth/userinfo.profile and
https://www.googleapis.com/auth/userinfo.email scopes, even though
we had requested the profile and email scopes. Those scopes are
equivalent, but our oauth library was throwing an error in:

```oauthlib.oauth2.rfc6749.parameters.validate_token_parameters```

because the granted scopes did not match the requested scopes.