### PR TITLE
And /me and /authorization endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -354,7 +354,7 @@ def get_user_info(token=None):
         resp = _get_user_info_from_token()
     # If there is a 5xx error, or some unexpected 4xx we will return the message but
     # leave the token's intact b/c they're not necessarily to blame for the error.
-    assert resp.status_code == 200, 'Failed to get user info: ' + resp.text
+    assert resp.status_code == 200, str(resp.text)
     return resp.json()
 
 

--- a/app.py
+++ b/app.py
@@ -380,7 +380,6 @@ def me():
             "name": "Jane Doe",
             "email": "jdoe@example.com",
             "avatar": "https:///lh6.googleusercontent.com/....",
-            "accessToken": "the access token"
         }
 
     In addition, if the access token was refreshed, the new access token
@@ -403,7 +402,6 @@ def me():
 
     output = dict((k, user_data[k]) for k in ('name', 'email'))
     output['avatar'] = user_data['picture']
-    output['accessToken'] = current_user.access_token
     return jsonify(output)
 
 

--- a/app.py
+++ b/app.py
@@ -326,11 +326,11 @@ def me():
     """
     returns information about the user making the request.
 
-    If authentication is enabled for the deployment, and there is no
+    If authentication is required for the deployment, and there is no
     access token, or it is expired and cannot be renewed, then return a
     401.
 
-    If authentication is not enabled for the deployment, and there is no
+    If authentication is not required for the deployment, and there is no
     access token, or it is expired and cannot be renewed, then return
     an anonymous user.
 

--- a/app.py
+++ b/app.py
@@ -346,6 +346,8 @@ def get_user_info(token=None):
     """
     resp = _get_user_info_from_token(token=token)
     if resp.status_code == 400:
+        if token is None:
+            raise ValueError('The provided token was not accepted')
         # token expired, try once more
         try:
             new_google_access_token()
@@ -403,7 +405,7 @@ def me():
         return e.message, 401
     except OAuth2Error as e:
         return 'Failed to get user info: ' + e.message, 401
-    if not whitelist_checker.is_authorized(user_data['email']):
+    if whitelist_checker is not None and not whitelist_checker.is_authorized(user_data['email']):
         return 'User no longer whitelisted', 401
     output = dict((k, user_data[k]) for k in ('name', 'email'))
     output['avatar'] = user_data['picture']


### PR DESCRIPTION
This is an extension of #59.

Both #50 and #52 are covered in this PR because there was going to be some code overlap.

These changes are currently deployed at jesse.ucsc-cgp-dev.org

There were a couple outstanding issues that @coverbeck and I were discussing.

1. One is the access token in the /me endpoint. This is now removed.
2. Another was https://github.com/DataBiosphere/cgp-dashboard/compare/feature/commons...feature/51-auth-endpoint?expand=1#diff-3f41e546893dc64b71aaacad12cad815R357 
   I was wondering if comment is along the lines of what you were thinking.