### PR TITLE
Fix how whitelist is checked (resolves #64)

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,7 +85,7 @@ login_manager.login_view = "login"
 login_manager.session_protection = "strong"
 
 # make a global bouncer instance to avoid needless re-instantiation
-if os.getenv('EMAIL_WHITELIST_NAME') is not None:
+if os.getenv('EMAIL_WHITELIST_NAME'):
     whitelist_checker = Bouncer(os.getenv('EMAIL_WHITELIST_NAME'))
 else:
     whitelist_checker = None


### PR DESCRIPTION
before, an empty string would be enough to indicate that a white-
list existed, but actually in the case of an empty string we want
to interpret that to mean there is no whitelist.