### PR TITLE
Don't say data is restricted when it's not.

### DIFF
--- a/app.py
+++ b/app.py
@@ -519,7 +519,7 @@ def html_rend(name):
     data = os.environ['DCC_DASHBOARD_SERVICE']
     coreClientVersion = os.getenv('DCC_CORE_CLIENT_VERSION', '1.1.0')
     if name == 'index':
-        auth_required = os.getenv('EMAIL_WHITELIST_NAME') is not None
+        auth_required = bool(os.getenv('EMAIL_WHITELIST_NAME'))
         contact_email = os.getenv('CONTACT_EMAIL', '')
         return render_template(name + '.html',
                                auth_required=auth_required,


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/DASH-30 and  DataBiosphere/cgp-boardwalk#92

EMAIL_WHITELIST_NAME is an empty string, not None, if it is not configured.