### PR TITLE
Access token not getting refreshed properly (fixes #75)

### DIFF
--- a/app.py
+++ b/app.py
@@ -362,7 +362,7 @@ def get_user_info(token=None):
     """
     resp = _get_user_info_from_token(token=token)
     if resp.status_code == 400:
-        if token is None:
+        if token:
             raise ValueError('The provided token was not accepted')
         # token expired, try once more
         try:

--- a/app.py
+++ b/app.py
@@ -355,7 +355,7 @@ def _get_user_info_from_token(token=None):
 
 def get_user_info(token=None):
     """
-    Get user's info, retry with refreshed token if failed, and raise AssertError
+    Get user's info, retry with refreshed token if failed, and raise ValueError
     or OAuth2Error if failure
 
     If access token is provided, use that first


### PR DESCRIPTION
When UI makes API call, it calls azul-webservice with a cookie, which
in turn calls `/authorization` endpoint in app.py. Because there was
a cookie, Authorization header is not sent, and hence `token` is `None`
when `get_user_info` is invoked. The code was immediately raising an
exception when the token was `None`; instead it should raise the exception
if the token is not `None`