### PR TITLE
Update pycrypto to pycryptodome (closes TLP-684)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pyopenssl==16.2.0
 flask-login==0.4.0
 oauth2client==4.1.2
 pyasn1==0.4.2
-pycrypto==2.6.1
+pycryptodome==3.6.6
 cgp-bouncer==0.1.0
 # urllib3 is required b/c otherwise the old version causes a weird error with python 2.7.9
 # it is a requirement for botocore which is required by cgp-bouncer


### PR DESCRIPTION
This upgrade patches two vulnerabilities in cgp-dashboard
arising from `pycrypto`, which has been effectively deprecated.
The patched vulnerabilities are:

* Arbitrary code execution (https://snyk.io/vuln/SNYK-PYTHON-PYCRYPTO-40249)
* Information exposure (https://snyk.io/vuln/SNYK-PYTHON-PYCRYPTO-42047)

`pycryptodome` is a drop-in replacement for `pycrypto` that patches
both of these vulnerabilities.