### PR TITLE
Removed program:start and program:init from supervisord.conf (fixes #84)

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,9 +1,6 @@
 [supervisord]
 nodaemon=true
 
-[program:start]
-command=bash -c "cd /app/; python -c 'from app import db; db.create_all()'"
-
 [program:uwsgi]
 command=/usr/local/bin/uwsgi --ini /etc/uwsgi/uwsgi.ini --ini /app/uwsgi.ini
 stdout_logfile=/dev/stdout
@@ -18,9 +15,3 @@ stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
-[program:init]
-command=/bin/bash /app/cron.sh
-stdout_logfile=/app/log/init_stdout.log
-stdout_logfile_maxbytes=0
-stderr_logfile=/app/log/init_stderr.log
-stderr_logfile_maxbytes=0


### PR DESCRIPTION
This PR works in conjunction with PR https://github.com/DataBiosphere/azul/pull/488 to address the problem of an apparent endless loop that ensues after executing 
`docker-compose -f dev.yml up` (when the docker compose network is in the down state). 

Specifically, I removed two _program_ sections from the configuration file `supervisord.conf` of the process control system _supervisor_ in the _dcc-dashboard_ directory (which is the name of _cgp-dashboard_ in the platform in feature/commons deployment). The removal of those names was necessary as they addressed functionality which does not exist in the code anymore:
* `app.py` does not contain a method `db`
* `cron.sh` does not exist in this directory

Implementation of changes in both repositories seems to fix that problem, and launches the `nginx` container as expected.