### PR TITLE
Use refresh token to refresh access token after 1 h (resolved #91)

### DIFF
--- a/app.py
+++ b/app.py
@@ -46,6 +46,7 @@ class Auth:
     REDIRECT_URI = DCC_DASHBOARD_PROTOCOL+'://'+DCC_DASHBOARD_HOST+'/gCallback'
     AUTH_URI = 'https://accounts.google.com/o/oauth2/auth'
     TOKEN_URI = 'https://accounts.google.com/o/oauth2/token'
+    REFRESH_URI = TOKEN_URI  # true for Google but not all providers
     USER_INFO = 'https://www.googleapis.com/userinfo/v2/me'
     REVOKE_TOKEN = 'https://accounts.google.com/o/oauth2/revoke'
     SCOPE = ['https://www.googleapis.com/auth/userinfo.profile',

--- a/app.py
+++ b/app.py
@@ -317,7 +317,7 @@ def new_google_access_token():
     app.logger.info('(MK comment) refresh_token: {}'.format(refresh_token))
     app.logger.info('(MK comment) resp[access_token]: {}'.format(resp['access_token']))    
     current_user.access_token = resp['access_token']
-    return resp['access_token']
+    return resp['access_token'], resp['refresh_token']
 
 
 def make_request(url, headers):
@@ -395,11 +395,16 @@ def get_user_info(token=None, user=None):
         # token expired, try once more
         try:
             app.logger.info('(MK comment) Trying to refresh access token.')
-            access_token = new_google_access_token()
+            access_token, refresh_token = new_google_access_token()
             user = load_user(current_user.get_id())
             setattr(user, 'access_token', access_token)
-            app.logger.info('(MK comment) user.access_token: {}'
+            app.logger.info('(MK comment) set user.access_token: {}'
                             .format(user.access_token))
+
+            setattr(user, 'refresh_token', refresh_token)
+            app.logger.info('(MK comment) set user.refresh_token: {}'
+                            .format(user.access_token))
+
         except OAuth2Error:
             # erase old tokens if they're broken / expired
             app.logger.warning('Could not refresh access token')

--- a/app.py
+++ b/app.py
@@ -432,7 +432,7 @@ def me():
 
 
 @app.route('/authorization')
-def authorization(user):
+def authorization():
     """
     This endpoint determines if the caller is authorized of not.
 
@@ -472,7 +472,6 @@ def authorization(user):
     # use access token in session
     try:
         user_data = get_user_info(auth_token)
-        resp = get_user_info(user)
         app.logger.info('(MK comment) user_data: {}'.format(user_data))
     except ValueError as e:
         return e.message, 401

--- a/app.py
+++ b/app.py
@@ -421,20 +421,6 @@ def get_user_info(token=None):
     return resp.json()
 
 
-def refresh_token():
-    """ Refreshes an expired access token using refresh token. """
-    token = session['oauth_token']
-
-    extra = {
-        'client_id': client_id,
-        'client_secret': client_secret,
-    }
-
-    google = OAuth2Session(client_id, token=token)
-    session['oauth_token'] = google.refresh_token(refresh_url, **extra)
-
-
-
 @app.route('/me')
 def me():
     """

--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ def _get_user_info_from_token(token=None):
         'access_token': current_user.access_token if token is None else token})
     return google.get(Auth.USER_INFO)
 
-
+@login_manager.needs_refresh_handler
 def get_user_info(token=None):
     """
     Get user's info, retry with refreshed token if failed, and raise ValueError
@@ -450,6 +450,11 @@ def authorization():
             return "Authorization must start with Bearer", 401
     if auth_token is None and current_user.is_anonymous:
         return "No token provided", 401
+
+    # If user is logged-in in a session it could be stale. Refresh it.
+    app.logger.info('Refreshing login')
+    login_manager.needs_refresh()
+
     # use access token in session
     try:
         user_data = get_user_info(auth_token)

--- a/app.py
+++ b/app.py
@@ -389,8 +389,8 @@ def get_user_info(token=None, user=None):
     resp = _get_user_info_from_token(token=token)
     app.logger.info('MK comment) get_user_info: initial resp. status: {}'
                     .format(resp.status_code))
-    # if resp.status_code == 400:
-    if True:
+    if resp.status_code == 400:
+    #if True:
         if token:
             raise ValueError('The provided token was not accepted')
         # Token expired, try to refresh access token.

--- a/app.py
+++ b/app.py
@@ -391,9 +391,11 @@ def get_user_info(token=None, user=None):
     # if True:
         if token:
             raise ValueError('The provided token was not accepted')
-        # token expired, try once more
+        # Token expired, try to refresh access token.
         try:
-            app.logger.info('(MK comment) Trying to refresh access token.')
+            app.logger.info('(MK comment) get_user_info status code: {}. '
+                            'Trying to refresh access token.'
+                            .format(resp.status_code))
             access_token, refresh_token = new_google_access_token()
             user = load_user(current_user.get_id())
             setattr(user, 'access_token', access_token)

--- a/app.py
+++ b/app.py
@@ -289,6 +289,7 @@ def parse_token():
     assert authorization_header is not None, "No Authorization header in the request"
     parts = authorization_header.split()
     app.logger.info('(MK comment) parts[0]: {}, parts[1]: {}'.format(parts[0], parts[1]))
+    # response = check_session(cookie=co)
     # Return the bearer and token string
     return parts[0], parts[1]
 
@@ -307,6 +308,8 @@ def new_google_access_token():
     }
     # this call may throw an OAuth2Error
     resp = oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token, **extra)
+    app.logger.info('(MK comment) response from new_google_access_token: {}'.
+                    format(resp))
     app.logger.info('(MK comment) refresh_token: {}'.format(refresh_token))
     app.logger.info('(MK comment) resp[access_token]: {}'.format(resp['access_token']))    
     current_user.access_token = resp['access_token']
@@ -327,7 +330,7 @@ def make_request(url, headers):
     except urllib2.HTTPError as e:
         return e.message, e.code
 
-
+# What method calls check_session? (don't see any) What is its function?
 @app.route('/check_session/<cookie>')
 def check_session(cookie):
     if not request.headers.get("Authorization", None):

--- a/app.py
+++ b/app.py
@@ -496,7 +496,7 @@ def authorization():
         app.logger.info(
             'Request path %s. No whitelist; User with email %s is logged in',
             request.path, user_data['email'])
-        user = load_user(current_user.get_id())
+        #user = load_user(current_user.get_id())
         return '', 204
     elif whitelist_checker.is_authorized(user_data['email']):
         app.logger.info(
@@ -516,8 +516,10 @@ def html_rend(name):
     Handle the templates differently depending
     on its name.
     """
+    # TODO: these variables are unused.
     data = os.environ['DCC_DASHBOARD_SERVICE']
     coreClientVersion = os.getenv('DCC_CORE_CLIENT_VERSION', '1.1.0')
+
     if name == 'index':
         auth_required = bool(os.getenv('EMAIL_WHITELIST_NAME'))
         contact_email = os.getenv('CONTACT_EMAIL', '')
@@ -610,7 +612,7 @@ def callback():
             return 'You are denied access.'
         return 'Error encountered.'
 
-    # TODO: What is a condition that denies a user access?
+    # (MK) Under what a condition is code and state not in _request_?
     if 'code' not in request.args and 'state' not in request.args:
         if current_user is not None:
             app.logger.info('Request path %s. '
@@ -693,7 +695,7 @@ def callback():
             get_flashed_messages()
             # Set a new success flash message
             flash('You are now logged in!', 'success')
-            # TODO: That message persist for too long - restrict life time.
+            # TODO: Looks like message persist for long - restrict life time?
             #  app.logger.info('Request path %s. User with email %s was logged in; redirecting to index URL', request.path, user_data['email'])
             # return redirect(url_for('index'))
             # (MK) changing redirect following login to file browser (DataBrowser).

--- a/app.py
+++ b/app.py
@@ -704,7 +704,7 @@ def callback():
                             'redirecting to boardwalk URL',
                             request.path,
                             user_data['email'])
-            return redirect(url_for('boardwalk'))
+            return redirect(url_for('index'))
 
         app.logger.error('Could not fetch information for current user')
         return 'Could not fetch your information.'

--- a/app.py
+++ b/app.py
@@ -310,7 +310,7 @@ def new_google_access_token():
         'client_secret': Auth.CLIENT_SECRET,
     }
     # this call may throw an OAuth2Error
-    resp = oauth.refresh_token(Auth.TOKEN_URI, refresh_token=refresh_token, **extra)
+    resp = oauth.refresh_token(Auth.REFRESH_URI, refresh_token=refresh_token, **extra)
     app.logger.info('(MK comment) response from new_google_access_token: {}'.
                     format(resp))
     app.logger.info('(MK comment) refresh_token: {}'.format(refresh_token))
@@ -412,11 +412,27 @@ def get_user_info(token=None):
             session.pop('refresh_token')
             raise
         resp = _get_user_info_from_token()
+        app.logger.info('MK comment) get_user_info: resp. status after refresh: {}'
+                    .format(resp.status_code))
     # If there is a 5xx error, or some unexpected 4xx we will return the message but
     # leave the token's intact b/c they're not necessarily to blame for the error.
     if resp.status_code != 200:
         raise ValueError(resp.text)
     return resp.json()
+
+
+def refresh_token():
+    """ Refreshes an expired access token using refresh token. """
+    token = session['oauth_token']
+
+    extra = {
+        'client_id': client_id,
+        'client_secret': client_secret,
+    }
+
+    google = OAuth2Session(client_id, token=token)
+    session['oauth_token'] = google.refresh_token(refresh_url, **extra)
+
 
 
 @app.route('/me')

--- a/app.py
+++ b/app.py
@@ -566,21 +566,34 @@ def callback():
     app.logger.info("(MK comment) This is request.args: {}".format(request.args))
     
     if current_user is not None and current_user.is_authenticated:
-        app.logger.info('Request path %s. Current user with ID %s is authenticated; redirecting to index URL', request.path, current_user.get_id())
+        app.logger.info('Request path %s. '
+                        'Current user with ID %s is authenticated; '
+                        'redirecting to index URL',
+                        request.path, current_user.get_id())
         return redirect(url_for('index'))
+
     if 'error' in request.args:
         if request.args.get('error') == 'access_denied':
             if current_user is not None:
-                app.logger.error('Request path %s. Current user with ID %s access is denied', request.path, current_user.get_id())
+                app.logger.error('Request path %s. '
+                                 'Current user with ID %s access is denied',
+                                 request.path, current_user.get_id())
             else:
-                app.logger.error('Request path %s. Access is denied for current user None', request.path)
+                app.logger.error('Request path %s. '
+                                 'Access is denied for current user None',
+                                 request.path)
             return 'You are denied access.'
         return 'Error encountered.'
+
     if 'code' not in request.args and 'state' not in request.args:
         if current_user is not None:
-            app.logger.info('Request path %s. Redirecting current user with ID %s to login URL', request.path, current_user.get_id())
+            app.logger.info('Request path %s. '
+                            'Redirecting current user with ID %s to login URL',
+                            request.path, current_user.get_id())
         else:
-            app.logger.info('Request path %s. Redirecting current user None to login URL', request.path)
+            app.logger.info('Request path %s. '
+                            'Redirecting current user None to login URL',
+                            request.path)
 
         return redirect(url_for('login'))
     else:  # (MK) how is this case WRT current_user and request.args defined?
@@ -593,16 +606,24 @@ def callback():
             app.logger.info('(MK comment) Got new token: {}'.format(token))
         except HTTPError:
             if current_user is not None:
-                app.logger.error('Request path %s. Could not fetch token for current user with ID %s', request.path, current_user.get_id())
+                app.logger.error(
+                    'Request path %s. '
+                    'Could not fetch token for current user with ID %s',
+                    request.path, current_user.get_id())
             else:
-                app.logger.error('Request path %s. Could not fetch token for current user None', request.path)
+                app.logger.error('Request path %s. '
+                                 'Could not fetch token for current user None',
+                                 request.path)
             return 'HTTPError occurred.'
         # Testing the token verification step.
         try:
             # jwt = verify_id_token(token['id_token'], Auth.CLIENT_ID)
             verify_id_token(token['id_token'], Auth.CLIENT_ID)
         except AppIdentityError:
-            app.logger.error('Request path %s. Could not verify token for current user with ID %s', request.path, current_user.get_id())
+            app.logger.error(
+                'Request path %s. '
+                'Could not verify token for current user with ID %s',
+                request.path, current_user.get_id())
             return 'Could not verify token.'
         # Check if you have the appropriate domain
         # Commenting this section out to let anyone with
@@ -614,21 +635,28 @@ def callback():
 
         google = get_google_auth(token=token)
         resp = google.get(Auth.USER_INFO)
+        app.logger.info("(MK comment) status code: {}".format(resp.status_code))
         if resp.status_code == 200:
             user_data = resp.json()
             email = user_data['email']
             # If so configured, check for whitelist and redirect to
             # unauthorized page if not in whitelist, e.g.,
-            if whitelist_checker is not None and not whitelist_checker.is_authorized(email):
-                    app.logger.info('Request path %s. User with email %s is not authorized', request.path, user_data['email'])
-                    return redirect(url_for('unauthorized', account=redact_email(email)))
+            if whitelist_checker is not None \
+                    and not whitelist_checker.is_authorized(email):
+                    app.logger.info('Request path %s. '
+                                    'User with email %s is not authorized',
+                                    request.path, user_data['email'])
+                    return redirect(url_for('unauthorized',
+                                            account=redact_email(email)))
+            # Instantiate user and set attributes.
             user = User()
-            # Set user attributes.
             for attr in 'email', 'name', 'picture':
                 setattr(user, attr, user_data[attr])
             for attr in 'refresh_token', 'access_token':
                 setattr(user, attr, token[attr])
-            app.logger.info('(MK comment) user object after setting refresh token: {}'.format(user))
+            app.logger.info(
+                '(MK comment) user object after setting refresh token: {}'
+                    .format(user))
             login_user(user)
             # Empty flashed messages
             get_flashed_messages()
@@ -637,8 +665,13 @@ def callback():
             # app.logger.info('Request path %s. User with email %s was logged in; redirecting to index URL', request.path, user_data['email'])
             # return redirect(url_for('index'))
             # (MK) changing redirect following login to file browser (DataBrowser).
-            app.logger.info('Request path %s. User with email %s was logged in; redirecting to boardwalk URL', request.path, user_data['email'])
+            app.logger.info('Request path %s. '
+                            'User with email %s was logged in; '
+                            'redirecting to boardwalk URL',
+                            request.path,
+                            user_data['email'])
             return redirect(url_for('boardwalk'))
+
         app.logger.error('Could not fetch information for current user')
         return 'Could not fetch your information.'
 

--- a/app.py
+++ b/app.py
@@ -383,8 +383,8 @@ def get_user_info(token=None, user=None):
     If access token is provided, use that first
     """
     resp = _get_user_info_from_token(token=token)
-    if resp.status_code == 400:
-    #if True:
+    #if resp.status_code == 400:
+    if True:
         #if token is None:
         if token:
             raise ValueError('The provided token was not accepted')

--- a/app.py
+++ b/app.py
@@ -403,7 +403,7 @@ def get_user_info(token=None, user=None):
 
             setattr(user, 'refresh_token', refresh_token)
             app.logger.info('(MK comment) set user.refresh_token: {}'
-                            .format(user.access_token))
+                            .format(user.refresh_token))
 
         except OAuth2Error:
             # erase old tokens if they're broken / expired

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ class Config:
     # Make cookies secure so that the tokens stored in them are safe and only travel over https
     SESSION_COOKIE_SECURE = True
     REMEMBER_COOKIE_SECURE = True
+    REMEMBER_COOKIE_REFRESH_EACH_REQUEST = True
 
 
 class DevConfig(Config):

--- a/app.py
+++ b/app.py
@@ -60,7 +60,6 @@ class Config:
     # Make cookies secure so that the tokens stored in them are safe and only travel over https
     SESSION_COOKIE_SECURE = True
     REMEMBER_COOKIE_SECURE = True
-    REMEMBER_COOKIE_REFRESH_EACH_REQUEST = True
 
 
 class DevConfig(Config):
@@ -567,6 +566,7 @@ def login():
 
 
 @app.route('/gCallback')
+@login_manager.needs_refresh
 def callback():
     """
     Callback method required by Google's OAuth 2.0

--- a/app.py
+++ b/app.py
@@ -365,7 +365,7 @@ def _get_user_info_from_token(token=None):
         'access_token': current_user.access_token if token is None else token})
     return google.get(Auth.USER_INFO)
 
-@login_manager.needs_refresh_handler
+#@login_manager.needs_refresh_handler
 def get_user_info(token=None):
     """
     Get user's info, retry with refreshed token if failed, and raise ValueError
@@ -374,7 +374,8 @@ def get_user_info(token=None):
     If access token is provided, use that first
     """
     resp = _get_user_info_from_token(token=token)
-    if resp.status_code == 400:
+    #if resp.status_code == 400:
+    if True:
         if token:
             raise ValueError('The provided token was not accepted')
         # token expired, try once more
@@ -451,9 +452,9 @@ def authorization():
     if auth_token is None and current_user.is_anonymous:
         return "No token provided", 401
 
-    # If user is logged-in in a session it could be stale. Refresh it.
-    app.logger.info('Refreshing login')
-    login_manager.needs_refresh()
+    # # If user is logged-in in a session it could be stale. Refresh it.
+    # app.logger.info('Refreshing login')
+    # login_manager.needs_refresh()
 
     # use access token in session
     try:

--- a/app.py
+++ b/app.py
@@ -397,14 +397,12 @@ def get_user_info(token=None):
                             'Trying to refresh access token.'
                             .format(resp.status_code))
             access_token, refresh_token = new_google_access_token()
-            user = load_user(current_user.get_id())
-            setattr(user, 'access_token', access_token)
+            current_user.access_token = access_token
+            current_user.refresh_token = refresh_token
             app.logger.info('(MK comment) set user.access_token: {}'
-                            .format(user.access_token))
-
-            setattr(user, 'refresh_token', refresh_token)
+                            .format(current_user.access_token))
             app.logger.info('(MK comment) set user.refresh_token: {}'
-                            .format(user.refresh_token))
+                            .format(current_user.refresh_token))
 
         except OAuth2Error:
             # erase old tokens if they're broken / expired

--- a/app.py
+++ b/app.py
@@ -373,8 +373,11 @@ def _get_user_info_from_token(token=None):
 
     returns the response object
     """
-    google = get_google_auth(token={
-        'access_token': current_user.access_token if token is None else token})
+    google = get_google_auth(
+        token={
+        'access_token': current_user.access_token if token is None else token},
+        state=session['oauth_state']
+    )
     return google.get(Auth.USER_INFO)
 
 

--- a/app.py
+++ b/app.py
@@ -379,7 +379,7 @@ def _get_user_info_from_token(token=None):
     return google.get(Auth.USER_INFO)
 
 
-def get_user_info(token=None, user=None):
+def get_user_info(token=None):
     """
     Get user's info, retry with refreshed token if failed, and raise ValueError
     or OAuth2Error if failure

--- a/app.py
+++ b/app.py
@@ -371,7 +371,7 @@ def _get_user_info_from_token(token=None):
         'access_token': current_user.access_token if token is None else token})
     return google.get(Auth.USER_INFO)
 
-#@login_manager.needs_refresh_handler
+
 def get_user_info(token=None, user=None):
     """
     Get user's info, retry with refreshed token if failed, and raise ValueError
@@ -566,7 +566,6 @@ def login():
 
 
 @app.route('/gCallback')
-@login_manager.needs_refresh
 def callback():
     """
     Callback method required by Google's OAuth 2.0
@@ -662,9 +661,9 @@ def callback():
             user = User()
             for attr in 'email', 'name', 'picture':
                 setattr(user, attr, user_data[attr])
-            get_user_info(token=token, user=user)  # get new access token
-            # for attr in 'refresh_token', 'access_token':
-            #     setattr(user, attr, token[attr])
+            #get_user_info(token=token, user=user)  # get new access token
+            for attr in 'refresh_token', 'access_token':
+                setattr(user, attr, token[attr])
             app.logger.info(
                 '(MK comment) user object after setting refresh token: {}'
                     .format(user))

--- a/app.py
+++ b/app.py
@@ -387,9 +387,8 @@ def get_user_info(token=None, user=None):
     If access token is provided, use that first
     """
     resp = _get_user_info_from_token(token=token)
-    #if resp.status_code == 400:
-    if True:
-        #if token is None:
+    if resp.status_code == 400:
+    # if True:
         if token:
             raise ValueError('The provided token was not accepted')
         # token expired, try once more

--- a/app.py
+++ b/app.py
@@ -389,7 +389,7 @@ def get_user_info(token=None, user=None):
     resp = _get_user_info_from_token(token=token)
     app.logger.info('MK comment) get_user_info: initial resp. status: {}'
                     .format(resp.status_code))
-    if resp.status_code == 400:
+    if resp.status_code == 401:
     #if True:
         if token:
             raise ValueError('The provided token was not accepted')

--- a/app.py
+++ b/app.py
@@ -387,8 +387,10 @@ def get_user_info(token=None, user=None):
     If access token is provided, use that first
     """
     resp = _get_user_info_from_token(token=token)
-    if resp.status_code == 400:
-    # if True:
+    app.logger.info('MK comment) get_user_info: initial resp. status: {}'
+                    .format(resp.status_code))
+    # if resp.status_code == 400:
+    if True:
         if token:
             raise ValueError('The provided token was not accepted')
         # Token expired, try to refresh access token.
@@ -471,7 +473,7 @@ def authorization():
         bearer, auth_token = parse_token()
         app.logger.info('(MK comment) bearer: {}, auth_token: {}'.format(bearer, auth_token))
     except AssertionError as e:
-        app.logger.error('(MK comment) Assertion error: ' + e.message)
+        app.logger.info('(MK comment) Assertion error: ' + e.message)
         auth_token = None
     else:
         if bearer != "Bearer":
@@ -588,8 +590,6 @@ def callback():
     app.logger.info("(MK comment) This is current_user: {}".format(current_user))
     app.logger.info("(MK comment) This is request.args: {}".format(request.args))
 
-
-    
     if current_user is not None and current_user.is_authenticated:
         app.logger.info('Request path %s. '
                         'Current user with ID %s is authenticated; '
@@ -597,7 +597,7 @@ def callback():
                         request.path, current_user.get_id())
         user = load_user(current_user.get_id())
         #return redirect(url_for('index'))
-        #return redirect(url_for('boardwalk'))
+        return redirect(url_for('boardwalk'))
 
     if 'error' in request.args:
         if request.args.get('error') == 'access_denied':
@@ -612,6 +612,7 @@ def callback():
             return 'You are denied access.'
         return 'Error encountered.'
 
+    # TODO: What is a condition that denies a user access?
     if 'code' not in request.args and 'state' not in request.args:
         if current_user is not None:
             app.logger.info('Request path %s. '
@@ -686,12 +687,16 @@ def callback():
             app.logger.info(
                 '(MK comment) user object after setting refresh token: {}'
                     .format(user))
+            app.logger.info('(MK comment) new refresh token: {}, '
+                            'new access token: {}'.format(user.access_token,
+                                                          user.refresh_token))
             login_user(user)
             # Empty flashed messages
             get_flashed_messages()
             # Set a new success flash message
             flash('You are now logged in!', 'success')
-            # app.logger.info('Request path %s. User with email %s was logged in; redirecting to index URL', request.path, user_data['email'])
+            # TODO: That message persist for too long - restrict life time.
+            #  app.logger.info('Request path %s. User with email %s was logged in; redirecting to index URL', request.path, user_data['email'])
             # return redirect(url_for('index'))
             # (MK) changing redirect following login to file browser (DataBrowser).
             app.logger.info('Request path %s. '

--- a/app.py
+++ b/app.py
@@ -6,7 +6,7 @@ from flask import Flask, url_for, redirect, \
     render_template, session, request, Response, \
     flash, get_flashed_messages, jsonify
 from flask_login import LoginManager, login_required, login_user, \
-    logout_user, current_user, UserMixin, confirm_login, user_needs_refresh
+    logout_user, current_user, UserMixin
 from oauthlib.oauth2 import OAuth2Error
 
 from elasticsearch_dsl import Search
@@ -203,8 +203,6 @@ class User(UserMixin):
                 print('Could not clear {} from session'.format(attr))
                 pass
 
-# (MK) Global user instance.
-#user = User()
 
 @login_manager.user_loader
 def load_user(user_id):
@@ -390,7 +388,7 @@ def get_user_info(token=None):
     app.logger.info('MK comment) get_user_info: initial resp. status: {}'
                     .format(resp.status_code))
     if resp.status_code == 401:
-    #if True:
+    #if True:  # useful to mimic a persistent 401 for testing
         if token:
             raise ValueError('The provided token was not accepted')
         # Token expired, try to refresh access token.


### PR DESCRIPTION
The good news is that a user is not prompted to log in again after 1 h anymore. 

Yet, I have doubts about the way I've implemented it and would appreciate suggestions. Specifically, `_get_user_info_from_token` returns a 401 if access token isn't provided. That happens once user has been logged in for more than 1 h. I then set both, new refresh and access tokens in the User object instance. I'm not sure though why, following that, `current_user.access_token` doesn't return the refreshed access token?

The observation is that once 1 h has passed each new GET request immediately executes line  https://github.com/DataBiosphere/cgp-dashboard/blob/fix/mkrause/91-refresh-auth-token/app.py#L390, indicating that the refreshed access token wasn't set. In other words, I would expect a refreshed access token to be valid again for 60 min before it expires.

The code still contains several comments, logged in `dcc-dashboard/logs/error_uwsgiB.log` (after `sudo -i`) which helped me debugging it, and which I plan to remove.

An instance is running at https://mkrause1.ucsc-cgp-dev.org. 